### PR TITLE
Chunk boundary check

### DIFF
--- a/drf_chunked_upload/views.py
+++ b/drf_chunked_upload/views.py
@@ -170,6 +170,12 @@ class ChunkedUploadView(ListModelMixin, RetrieveModelMixin,
         chunk_size = end - start + 1
         max_bytes = self.get_max_bytes(request)
 
+        if end > total:
+            raise ChunkedUploadError(
+                status=status.HTTP_400_BAD_REQUEST,
+                detail='End of chunk exceeds reported total (%s bytes)' % total
+            )
+
         if max_bytes is not None and total > max_bytes:
             raise ChunkedUploadError(
                 status=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
It appears `total` in `_put_chunk` is parsed from input and checked against maximum byte limit, but not against actual file/chunk size. AFAIK neither django nor DRF validates `Content-Range` header, so in current state, a malicious client could upload a file larger than maximum byte limit by reporting false total size.

This PR fixes that by comparing `end` with `total`. Since `start` is checked against offset recorded in DB, and `chunk_size` is calculated using `start` and `end` and is checked against actual chunk size, checking `end` against `total` would assure appending this chunk will not make actual file size exceed reported `total`, which does not exceed maximum byte limit.