### PR TITLE
Use input for Python 3

### DIFF
--- a/drf_chunked_upload/management/commands/delete_expired_uploads.py
+++ b/drf_chunked_upload/management/commands/delete_expired_uploads.py
@@ -133,6 +133,6 @@ class Command(BaseCommand):
         prompt = PROMPT_MSG.format(obj=chunked_upload) + u' (y/n): '
 
         while True not in ('y', 'n'):
-            answer = VALID_RESP.get(raw_input(prompt).lower(), None)
+            answer = VALID_RESP.get(input(prompt).lower(), None)
             if answer is not None:
                 return answer


### PR DESCRIPTION
`raw_input()` does not exist on Python 3