### PR TITLE
fix `completed_at` default value of the method `completed` of the model class `AbstractChunkedUpload`

### DIFF
--- a/src/drf_chunked_upload/models.py
+++ b/src/drf_chunked_upload/models.py
@@ -123,7 +123,10 @@ class AbstractChunkedUpload(models.Model):
                             size=self.file.size)
 
     @transaction.atomic
-    def completed(self, completed_at=timezone.now(), ext=_settings.COMPLETE_EXT):
+    def completed(self, completed_at=None, ext=_settings.COMPLETE_EXT):
+        if completed_at is None:
+            completed_at = timezone.now()
+
         if ext != _settings.INCOMPLETE_EXT:
             original_path = self.file.path
             self.file.name = os.path.splitext(self.file.name)[0] + ext


### PR DESCRIPTION
The call to func in the signature will be executed when the Python interpreter is started. So attr `completed_at` will have the same default value for the all lifetime of the process.

In order for the default value to be correctly updated for each call to the `completed` method, it must be evaluated in the body of the function.

