### PR TITLE
update python/dependency test versions

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -2,10 +2,10 @@ name: Python Tests
 on:
   push:
     branches:
-      main
+      - main
   pull_request:
     branches:
-      main
+      - main
 jobs:
   tests:
     name: Python ${{ matrix.python-version }}
@@ -13,11 +13,12 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - '3.6'
         - '3.7'
         - '3.8'
         - '3.9'
         - '3.10'
+        - '3.11'
+        - '3.12'
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -18,7 +18,6 @@ jobs:
         - '3.9'
         - '3.10'
         - '3.11'
-        - '3.12'
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
     author_email='jkeifer0@gmail.com',
     url='https://github.com/jkeifer/drf-chunked-upload',
     install_requires=[
-        'Django>=2.2,<5.0',
-        'djangorestframework>=3.11,<4.0',
+        'Django>=2.2',
+        'djangorestframework>=3.11',
     ],
     python_requires='>3.7',
     license='MIT-Zero',

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setup(
         'Django>=2.2,<5.0',
         'djangorestframework>=3.11,<4.0',
     ],
-    python_requires='>3.6',
+    python_requires='>3.7',
     license='MIT-Zero',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
 envlist =
-       {py36,py37}-django22-drf{311,312,313},
-       {py36,py37,py38,py39}-django30-drf{311,312,313},
-       {py36,py37,py38,py39}-django31-drf{311,312,313},
-       {py36,py37,py38,py39,py310}-django32-drf{311,312,313},
-       {py38,py39,py310}-django40-drf{313},
-       {py38,py39,py310}-djangomain-drf{313},
+       {py36,py37}-django22-drf{311,312,313,314},
+       {py36,py37,py38,py39}-django30-drf{311,312,313,314},
+       {py36,py37,py38,py39}-django31-drf{311,312,313,314},
+       {py36,py37,py38,py39,py310,py311}-django32-drf{311,312,313,314},
+       {py38,py39,py310,py311}-django40-drf{313,314},
+       {py38,py39,py310,py311}-django41-drf{313,314},
+       {py38,py39,py310,py311}-django42-drf{313,314},
+       {py38,py39,py310,py311}-djangomain-drf{313,314},
 
 [testenv]
 commands = pytest --cov drf_chunked_upload
@@ -38,4 +40,7 @@ ignore_outcome = true
 ignore_outcome = true
 
 [testenv:py310-djangomain]
+ignore_outcome = true
+
+[testenv:py311-djangomain]
 ignore_outcome = true

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ envlist =
        {py36,py37,py38,py39,py310,py311}-django32-drf{311,312,313,314},
        {py38,py39,py310,py311}-django40-drf{313,314},
        {py38,py39,py310,py311}-django41-drf{313,314},
-       {py38,py39,py310,py311}-django42-drf{313,314},
-       {py38,py39,py310,py311}-djangomain-drf{313,314},
+       {py38,py39,py310,py311}-django42-drf{314},
+       {py38,py39,py310,py311}-djangomain-drf{314},
 
 [testenv]
 commands = pytest --cov drf_chunked_upload

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-       {py36,py37}-django22-drf{311,312,313,314},
-       {py36,py37,py38,py39}-django30-drf{311,312,313,314},
-       {py36,py37,py38,py39}-django31-drf{311,312,313,314},
-       {py36,py37,py38,py39,py310,py311}-django32-drf{311,312,313,314},
+       {py37}-django22-drf{311,312,313},
+       {py37,py38,py39}-django30-drf{311,312,313,314},
+       {py37,py38,py39}-django31-drf{311,312,313,314},
+       {py37,py38,py39,py310,py311}-django32-drf{311,312,313,314},
        {py38,py39,py310,py311}-django40-drf{313,314},
        {py38,py39,py310,py311}-django41-drf{313,314},
        {py38,py39,py310,py311}-django42-drf{314},

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
        {py38,py39,py310,py311}-django40-drf{313,314},
        {py38,py39,py310,py311}-django41-drf{313,314},
        {py38,py39,py310,py311}-django42-drf{314},
-       {py38,py39,py310,py311}-djangomain-drf{314},
+       {py310,py311}-djangomain-drf{314},
 
 [testenv]
 commands = pytest --cov drf_chunked_upload

--- a/tox.ini
+++ b/tox.ini
@@ -19,10 +19,13 @@ deps =
         django31: Django>=3.1,<3.2
         django32: Django>=3.2,<4.0
         django40: Django>=4.0,<4.1
+        django41: Django>=4.1,<4.2
+        django42: Django>=4.2,<4.3
         djangomain: https://github.com/django/django/archive/main.tar.gz
         drf311: djangorestframework>=3.11,<3.12
         drf312: djangorestframework>=3.12,<3.13
-        drf313: djangorestframework>=3.13,<4.0
+        drf313: djangorestframework>=3.13,<3.14
+        drf314: djangorestframework>=3.14,<4.0
         -rrequirements/testing.txt
 
 [pytest]


### PR DESCRIPTION
3.6 is EOL and tests are failing, and new python/django/drf versions are now available. Updating test matrix to test all.

Also loosening max version dependencies as most often major versions don't break functionality for libs like this.